### PR TITLE
Correct usage of GDA2020

### DIFF
--- a/spec/05-patterns.adoc
+++ b/spec/05-patterns.adoc
@@ -346,10 +346,10 @@ This is as per a rule in the <<Spatial Reasoning, Spatial Reasoning>> part of th
 
 All spatial data supplied according to ABIS _MUST_ use the GDA2020 Coordinate Reference System. Systems such as WGS84, GDA94 or others _MUST NOT_ be used.
 
-Since spatial data formulated according to GeoSPARQL only use the Well-Known Text format - see the <<Geometry Literals, Geometry Literals>> section above - and that format defaults to WGS84, the use of GDA2020 must be indicated in the WKT, as per the https://docs.ogc.org/is/22-047r1/22-047r1.html#_rdfs_datatype_geowktliteral[GeoSPARQL WKT guidance] using the IRI `https://epsg.io/7843` for the CRS. For example, a `POINT` at `(123, -45) would have WKT like this:
+Since spatial data formulated according to GeoSPARQL only use the Well-Known Text format - see the <<Geometry Literals, Geometry Literals>> section above - and that format defaults to OGC:CRS84, the use of GDA2020 must be indicated in the WKT, as per the https://docs.ogc.org/is/22-047r1/22-047r1.html#_rdfs_datatype_geowktliteral[GeoSPARQL WKT guidance] using the IRI `http://www.opengis.net/def/crs/EPSG/0/7844` or `https://epsg.io/7844` for the CRS. Remember when converting from OGC CRS84 (the default WKT crs) to GDA2020 the axis order must also be reversed. For example, a `POINT` at `(123.0 -45.0)` would have WKT like this:
 
 ----
-<https://epsg.io/7843> POINT (123, -45)
+"<https://epsg.io/7844> POINT (-45.0 123.0)"geo:wktLiteral
 ----
 
 ==== Aggregation Reasoning


### PR DESCRIPTION
Four fixes:
1) Use EPSG:7844 for GDA2020, not EPSG:7843.
    * The difference is that 7843 is the "projected" form, with units in meters X, meters Y. And 7844 is the "unprojected" form, with units in degrees E, degrees N. The examples given are in degrees, so switch to 7844.
    * Note, there is also a third form called EPSG:7845 that is in degrees but with an additional altitude/height component. We could probably also support that one in BDR.
2) Include the CRS IRI form of `http://www.opengis.net/def/crs/EPSG/0/7844` in addition to `https://epsg.io/7844`.
    * The former is more commonly used and has native handling in most GeoSPARQL implementations.
3) Fix typo, the WKT standard defaults to `OGC:CRS84` CRS when no CRS is given. This is not the same as `WGS84`.
    * The difference is CRS84 uses longitude-latitude axis ordering, and WGS84 uses latitude-longitude axis ordering.
4) Ensure the example WKT given with GDA2020 uses the correct latitude-longitude axis ordering, as defined by EPSG:7844.
