### PR TITLE
Rename BiodiversityOccurrenceRecord to BiodiversityRecord

### DIFF
--- a/spec/05-patterns.adoc
+++ b/spec/05-patterns.adoc
@@ -181,7 +181,7 @@ Multiple alternate identifiers may be given, as long as their datatypes are uniq
 
 === Data Cataloguing
 
-ABIS provides representations of chunks of data for management - cataloguing, data governance and so on. It does this by implementing a very simple, and common, catalogue model which consists of _catalogues_ (or _catalogs_, for Americans) that contain _datasets_ or other kinds of _resources_  such as _vocabularies_. ABIS then insists that _datasets_ must, in turn, contain _biodiversity occurrence records_ for records of such as what ABIS is all about.
+ABIS provides representations of chunks of data for management - cataloguing, data governance and so on. It does this by implementing a very simple, and common, catalogue model which consists of _catalogues_ (or _catalogs_, for Americans) that contain _datasets_ or other kinds of _resources_  such as _vocabularies_. ABIS then insists that _datasets_ must, in turn, contain _biodiversity records_ for records of such as what ABIS is all about.
 
 This models is as per <<#cat-model-overview-pattern, Figure 4>>, below, which is taken from the <<Annex A: ABIS Catalogue Model, ABIS Catalogue Model>>, detailed in full in Annex A.
 
@@ -198,21 +198,21 @@ implemented by <<SDO, schema.org>> and <<DCAT, the Data Catalog Vocabulary (DCAT
 
 ABIS is fundamentally about records of the occurrence of biodiversity. For this reason, ABIS contains representations of chunks of data, as per the <<Data Cataloguing, Data Cataloguing>> pattern above, a  representation of an _occurrence_ and a mechanism to link them.
 
-The ABIS class <<abis:BiodiversityOccurrenceRecord, Biodiversity Occurrence Record>> represents a single recording of an occurrence. This is usually a single row in a spreadsheet of biodiversity observations, or a single point of a map of occurrences. It is linked to the representation of actual occurrence itself, represented by the <<DWC, Darwin Core Terms>>'s <<dwc:Occurrence, Occurrence>> class.
+The ABIS class <<abis:BiodiversityRecord, BiodiversityRecord>> represents a single recording of an occurrence or recording of the results of a survey. This is usually a single row in a spreadsheet of biodiversity observations, or a single point of a map of occurrences. It is linked to the representation of actual occurrence itself, represented by the <<DWC, Darwin Core Terms>>'s <<dwc:Occurrence, Occurrence>> class.
 
 The reason for this distinction between representations of the _record of the occurrence_ and the _occurrence_ itself is because some data models record metadata about the recording itself - who did it, where it is stored and managed, what ID the recording has etc. - and some don't, choosing to focus only on the where/what/when of the occurrence.
 
 [NOTE]
 ====
-For data in the ABIS format being submitted to systems such as the <<BDR, Biodiversity Data Repository>> where the data origin has a "Record ID" or similar, this ID should be preserved as a property of instances of the <<abis:BiodiversityOccurrenceRecord, Biodiversity Occurrence Record>> class as a non-IRI alternate identifier, as per the <<Alternate IDs - non-IRIs, Alternate IDs - non-IRIs>> pattern.
+For data in the ABIS format being submitted to systems such as the <<BDR, Biodiversity Data Repository>> where the data origin has a "Record ID" or similar, this ID should be preserved as a property of instances of the <<abis:BiodiversityRecord, Biodiversity Record>> class as a non-IRI alternate identifier, as per the <<Alternate IDs - non-IRIs, Alternate IDs - non-IRIs>> pattern.
 ====
 
-The relationship between a <<abis:BiodiversityOccurrenceRecord, Biodiversity Occurrence Record>> and the <<dwc:Occurrence, Occurrence>> it is about is given with the <<schema:about, schema:about>> predicate, like this:
+The relationship between a <<abis:BiodiversityRecord, Biodiversity Record>> and the <<dwc:Occurrence, Occurrence>> it is about is given with the <<schema:about, schema:about>> predicate, like this:
 
 [source,turtle]
 ----
 ex:record-1234
-    a abis:BiodiversityOccurrenceRecord
+    a abis:BiodiversityRecord
     # ... other info
     schema:about ex:occurrence-9876 ;  # <-- this is the link
 .

--- a/spec/06-models.adoc
+++ b/spec/06-models.adoc
@@ -157,9 +157,9 @@ From the <<TERN Ontology, TERN Ontology>>:
 
 Introduced:
 
-* <<abis:BiodiversityOccurrenceRecord, (Biodiversity Occurrence) Record>> - A unit of information that records the observation of a biodiversity occurrence
+* <<abis:BiodiversityRecord, (Biodiversity) Record>> - A unit of information that represents the record of a biodiversity occurrence or a biodiversity survey
 
-The use of the existing classes is as per <<SDO, schema.org>>'s basic data cataloguing, which is based on the <<DCAT, Data Catalog Vocabulary (DCAT)>> standard, where `DataCatalog` instances contain `Dataset` instances. This model's extension with the definition of the (Biodiversity Occurrence) Record class - `Record` - is to define data elements within datasets that are specifically about biodiversity occurrences.
+The use of the existing classes is as per <<SDO, schema.org>>'s basic data cataloguing, which is based on the <<DCAT, Data Catalog Vocabulary (DCAT)>> standard, where `DataCatalog` instances contain `Dataset` instances. This model's extension with the definition of the (Biodiversity) Record class - `Record` - is to define data elements within datasets that are specifically about biodiversity occurrences or about biodiversity surveys.
 
 [NOTE]
 ====

--- a/spec/11-reasoning-rules.adoc
+++ b/spec/11-reasoning-rules.adoc
@@ -35,7 +35,7 @@ WHERE {
     # ...
 }
 ----
-| R02 | Calculate `abis:BiodiversityOccurrenceRecord` instances from ... | - a|
+| R02 | Calculate `abis:BiodiversityRecord` instances from ... | - a|
 [sources,sparql]
 ----
 PREFIX abis: <https://linked.data.gov.au/def/abis/>
@@ -43,7 +43,7 @@ PREFIX tern <https://w3id.org/tern/ontologies/tern/>
 PREFIX void: <http://rdfs.org/ns/void#>
 
 CONSTRUCT {
-    ?boc a abis:BiodiversityOccurrenceRecord .
+    ?boc a abis:BiodiversityRecord .
 }
 WHERE {
     # ...
@@ -165,7 +165,7 @@ WHERE {
 [discrete]
 ==== Record Rule
 
-This rule allows for the creation of <<abis:BiodiversityOccurrenceRecord, Record>> instances from <<TERN Ontology, TERN Ontology>> data that doesn't directly indicate such as class of object.
+This rule allows for the creation of <<abis:BiodiversityRecord, Record>> instances from <<TERN Ontology, TERN Ontology>> data that doesn't directly indicate such as class of object.
 
 [discrete]
 ==== Spatial Reasoning

--- a/spec/50_annex_a.adoc
+++ b/spec/50_annex_a.adoc
@@ -5,7 +5,7 @@
 .An overview of the ABIS Catalogue Model's classes and their relationships
 image::img/cat-model.svg[ABIS Catalogue Model overview,align="center",width=150]
 
-<<schema:DataCatalog, DataCatalog>>s are curated lists of <<tern:Dataset, Dataset>>s that contain <<abis:BiodiversityOccurrenceRecord, Biodiversity Occurrence Record>>s (just 'Records').
+<<schema:DataCatalog, DataCatalog>>s are curated lists of <<tern:Dataset, Dataset>>s that contain <<abis:BiodiversityRecord, Biodiversity Record>>s (just 'Records').
 
 The Dataset class is taken from the <<TERN Ontology, TERN Ontology>> and normal <<SDO, schema.org>> data catalogue modelling (informed by <<DCAT, DCAT>>) is used so that datasets are _creative work_ objects and may be described with metadata such as _creator_, _issued date_, etc.
 
@@ -23,7 +23,7 @@ See the <<BDR Profile, BDR Profile>> for the requirements of ABIS Catalogue Mode
 |===
 |*<<IRI, IRI>>* | https://linked.data.gov.au/def/abis/projects
 |*https://schema.org/name[Name]* | ABIS Data Release Model
-|*https://www.w3.org/TR/skos-reference/#definition[Definition]* | This model is for curated lists - catalogues - of data resources - datasets - that contains information about biodiversity occurrences - biodiversity occurrence records.
+|*https://www.w3.org/TR/skos-reference/#definition[Definition]* | This model is for curated lists - catalogues - of data resources - datasets - that contains information about biodiversity occurrences and surveys - biodiversity records.
 |*https://schema.org/dateCreated[Created Date]* | 2024-07-15
 |*https://schema.org/dateModified[Modified Date]* | 2024-07-22
 |*https://schema.org/dateIssued[Issued Date]* | 2023-07-30
@@ -57,7 +57,7 @@ image::img/cat-model-equivalences.svg[ABIS Catalogue Model class equivalences,al
 
 Classes defined here:
 
-* <<abis:BiodiversityOccurrenceRecord, Record>>
+* <<abis:BiodiversityRecord, Record>>
 
 Classes defined elsewhere:
 
@@ -65,8 +65,8 @@ Classes defined elsewhere:
 * <<tern:Dataset, Dataset>>
 * <<dwc:Occurrence, Occurrence>>
 
-[[abis:BiodiversityOccurrenceRecord]]
-==== BiodiversityOccurrenceRecord (Record)
+[[abis:BiodiversityRecord]]
+==== BiodiversityRecord (Record)
 
 // [#proj-project,link="img/proj-project.svg"]
 // .The Projects Model `Project` Class and its expected predicates
@@ -76,11 +76,11 @@ Classes defined elsewhere:
 |===
 | Property | Value
 
-| <<IRI, IRI>> | `abis:BiodiversityOccurrenceRecord`
+| <<IRI, IRI>> | `abis:BiodiversityRecord`
 | https://www.w3.org/TR/rdf12-schema/#ch_subclassof[Subclass of] | https://www.w3.org/TR/prov-o/#Entity[`Entity`]
 | https://www.w3.org/TR/rdf12-schema/#ch_isdefinedby[Is Defined By] | <<TERN Ontology, TERN Ontology>>
 | https://www.w3.org/TR/skos-reference/#prefLabel[Preferred Label] | Record
-| https://www.w3.org/TR/skos-reference/#altLabel[Alternate Label Label] | Biodiversity Occurrence Record
+| https://www.w3.org/TR/skos-reference/#altLabel[Alternate Label Label] | Biodiversity Record
 | https://www.w3.org/TR/skos-reference/#definition[Definition] | The recording of an Occurrence.
 | https://www.w3.org/TR/skos-reference/#definition[History Note] | Defined by the BDR Team in 2024 to better facilitate the management of ABIS data such as linking BDR data to original non-ABIS records in Submitting Organisations' data holdings
 | Expected Properties | <<schema:identifier, identifier>>, <<schema:about, about>>
@@ -107,7 +107,7 @@ a|
 .
 
 :record-001
-    a abis:BiodiversityOccurrenceRecord ;
+    a abis:BiodiversityRecord ;
     # a non-IRI identifier for this Record, as found in the original
     # data held by the Submitting Organisation
     schema:identifier "R1234"^^bdr-dt:OrgMRecordId ;
@@ -168,7 +168,7 @@ Predicates defined elsewhere:
 | https://www.w3.org/TR/skos-reference/#definition[Definition] | The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc.
 | https://www.w3.org/TR/skos-reference/#scopeNote[Scope Note] | Use this predicate to indicate a non-IRI identifier for an ABIS object identified, with ABIS use, by an IRI. A datatype MUST be assigned to the non-IRI identifier value
 | https://www.w3.org/TR/rdf12-schema/#ch_isdefinedby[Is Defined By] | <<SDO, schema.org>>
-| https://www.w3.org/TR/skos-reference/#example[Example] a| See the example for <<abis:BiodiversityOccurrenceRecord, Record>>
+| https://www.w3.org/TR/skos-reference/#example[Example] a| See the example for <<abis:BiodiversityRecord, Record>>
 |===
 
 [discrete]
@@ -184,7 +184,7 @@ Predicates defined elsewhere:
 | https://www.w3.org/TR/skos-reference/#definition[Definition] | The subject matter of the content.
 | https://www.w3.org/TR/skos-reference/#scopeNote[Scope Note] | Use this predicate to indicate the Occurrence that this Record is about
 | https://www.w3.org/TR/rdf12-schema/#ch_isdefinedby[Is Defined By] | <<SDO, schema.org>>
-| https://www.w3.org/TR/skos-reference/#example[Example] a| See the example for <<abis:BiodiversityOccurrenceRecord, Record>>
+| https://www.w3.org/TR/skos-reference/#example[Example] a| See the example for <<abis:BiodiversityRecord, Record>>
 |===
 
 === A.5. Validator


### PR DESCRIPTION
Replace BiodiversityOccurrenceRecord with BiodiversityRecord, because the record may be about something that is _not_ a species occurrence, eg, a record of "Plot selection and setup" or a record of "population density".