### PR TITLE
Switch to two-slash file protocol links

### DIFF
--- a/validators/abis.ttl
+++ b/validators/abis.ttl
@@ -27,28 +27,28 @@ ont:
         [
             schema:name "GeoSPARQL" ;
             schema:url
-                "file:///geo.ttl" ,
+                "file://geo.ttl" ,
                 "http://www.opengis.net/def/geosparql/validator" ;
             schema:identifier "http://www.opengis.net/def/geosparql/validator" ;
         ] ,
         [
             schema:name "SOSA" ;
             schema:url
-                "file:///sosa.ttl" ;
+                "file://sosa.ttl" ;
                 # "https://linked.data.gov.au/def/sosa-validator" ;
             schema:identifier "https://linked.data.gov.au/def/sosa-validator" ;
         ] ,
         [
             schema:name "TERN Ontology" ;
             schema:url
-                "file:///tern.ttl" ;
+                "file://tern.ttl" ;
                 # "https://w3id.org/tern/shapes/tern/" ;
             schema:identifier "https://w3id.org/tern/shapes/tern/" ;
         ] ,
         [
             schema:name "VocPub" ;
             schema:url
-                "file:///vocpub.ttl" ,
+                "file://vocpub.ttl" ,
                 "https://w3id.org/profile/vocpub/validator" ;
             schema:identifier "https://w3id.org/profile/vocpub/validator" ;
         ] ;

--- a/validators/bdr-profile.ttl
+++ b/validators/bdr-profile.ttl
@@ -32,7 +32,7 @@ ds:
         [
             schema:name "ABIS" ;
             schema:url
-                "file:///abis.ttl" ,
+                "file://abis.ttl" ,
                 "https://linked.data.gov.au/def/abis/validator" ;
             schema:identifier "https://linked.data.gov.au/def/abis/validator" ;
         ] ;


### PR DESCRIPTION
In Linux and Unix-based OS (Including MacOS), the pattern `file:///abis.ttl` with three slashes expands to:
`file://` + `/abis.ttl` that represents an absolute file path.

These `owl:imports` file paths are supposed to be relative paths, so simply removing the third slash fixes this for Linux and Unix OS.

The two-slash vs three-slash situation on Windows is much more complicated, but I believe windows also supports the two-slash relative file:// paths since 2018. 

There is no one right answer here, but these changes were enough to get these files working in PySHACL on my Linux laptop.