### PR TITLE
Refactor shape-01 , remove 02 and 03

### DIFF
--- a/validators/abis.ttl
+++ b/validators/abis.ttl
@@ -14,15 +14,13 @@ ont:
     schema:creator <https://linked.data.gov.au/org/bdr-team> ;
     schema:publisher <https://linked.data.gov.au/org/ausbigg> ;
     schema:dateCreated "2022-05-11"^^xsd:date ;
-    schema:dateModified "2024-09-23"^^xsd:date ;
+    schema:dateModified "2026-05-06"^^xsd:date ;
     schema:license <http://purl.org/NET/rdflicense/cc-by4.0> ;
     schema:copyrightNotice "(c) 2024 AusBIGG" ;
     owl:versionIRI :1.0 ;
     owl:versionInfo """1.0 First version""" ;
     schema:hasPart
-        :shape-01 ,
-        :shape-02 ,
-        :shape-03 ;
+        :shape-01 ;
     owl:imports
         [
             schema:name "GeoSPARQL" ;

--- a/validators/abis.ttl
+++ b/validators/abis.ttl
@@ -68,18 +68,13 @@ ont:
 
 :shape-01
     a sh:NodeShape ;
+    sh:property
+        [
+            sh:class tern:Observation ;
+            sh:minCount 1 ;
+            sh:path sosa:hasMember ;
+        ] ;
     sh:targetClass tern:ObservationCollection ;
-    sh:property [
-        sh:path sosa:hasMember ;
-        sh:minCount 1 ;
-        sh:class tern:Observation ;
-    ] ;
-.
-
-:shape-02
-    a sh:NodeShape ;
-.
-
-:shape-03
-    a sh:NodeShape ;
+    sh:message "The Observation Collection has less than one member Observation" ;
+    schema:name "Observation Collection members" ; 
 .


### PR DESCRIPTION
Have done some digging around - the place-holder shapes 02 and 03 do not seem to be in development, and they create a bit of noise for validation - have removed these.

Also refactored shape-01 for ValPub compliance.

Also logged: https://github.com/dcceew-bdr/bdr-catalogues/issues/17